### PR TITLE
Push materialisation mutex deep into materialiser; Fix IAM benchmark build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # About this branch
 
-This branch is experimental. It rewrites the reasoner, with 2 major changes:
+This branch is experimental. It rewrites the reasoner, with 3 major changes:
 1. **It uses only actors, as opposed to a mix of actors & streams.**
    * Roughly, one actor maps to one 'goal'. The messages remain small - Only the size of the answer being carried.
 2. **The 'monitor' has been replaced with a local termination algorithm.** 
    * The monitor was an actor which constructed a copy of the reasoner graph and counted active nodes + in-flight messages in each 'subgraph'.
    This means it had to be informed of every node, dependency and message.
    * The new algorithm is based on the spanning tree approaches to termination in message-passing systems. It achieves 'incremental completion', as it is able to determine the completion of a 'strongly connected component' (SCC) - the unit of termination. This was partially inspired by the incremental-termination of XSB's SLG-WAM.
-
+3. We introduce a flag in Materliaser called `RELAXED_RELATION_INFERENCE_SEMANTICS` which skips the lookup and will insert a new relation into the database even if a persisted relation which subsumes it already exists.
+   - I did not enable it at the time of writing this readme, but it's worth checking.
 
 ### Test status
 When this readme was written, all 'reasoning' tests were passing, however the recursive verification of explanations were failing due to discrepancies in how the reasoner & the forward chaining oracle decide what is and isn't explainable.

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -338,9 +338,10 @@ public class Rule {
         public abstract Materialisable materialisable(ConceptMap whenConcepts, ConceptManager conceptMgr);
 
         Optional<Map<Identifier.Variable, Concept>> materialiseAndBind(
+                Materialiser materialiser,
                 ConceptMap whenConcepts, TraversalEngine traversalEng, ConceptManager conceptMgr
         ) {
-            return Materialiser.materialise(materialisable(whenConcepts, conceptMgr), traversalEng, conceptMgr)
+            return materialiser.materialise(materialisable(whenConcepts, conceptMgr), traversalEng, conceptMgr)
                     .map(materialisation -> materialisation.bindToConclusion(this, whenConcepts));
         }
 

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -120,6 +120,10 @@ public class Reasoner {
         return answers;
     }
 
+    public ReasonerPerfCounters perfCounters() {
+        return perfCounters;
+    }
+
     private Disjunction filterUnanswerable(Disjunction disjunction) {
         return new Disjunction(iterate(disjunction.conjunctions()).filter(Conjunction::isAnswerable).toList());
     }
@@ -171,11 +175,10 @@ public class Reasoner {
     }
 
     private boolean mayReason(Disjunction disjunction, Context.Query context) {
-        return true; // TODO: Fix this
-//        if (!context.options().infer() || context.transactionType().isWrite() || !logicMgr.rules().hasNext()) {
-//            return false;
-//        }
-//        return mayReason(disjunction);
+        if (!context.options().infer() || context.transactionType().isWrite() || !logicMgr.rules().hasNext()) {
+            return false;
+        }
+        return mayReason(disjunction);
     }
 
     private boolean mayReason(Disjunction disjunction) {

--- a/reasoner/common/ReasonerPerfCounters.java
+++ b/reasoner/common/ReasonerPerfCounters.java
@@ -24,6 +24,8 @@ public class ReasonerPerfCounters extends PerfCounters {
     public static final String COMPOUND_STREAMS = "streams_compound_streams";
     public static final String COMPOUND_STREAM_MESSAGES_RECEIVED = "streams_compound_stream_messages_received";
     public static final String RETRIEVABLE_PROCESSORS = "processors_retrievable";
+    public static final String RESOLVABLE_NODES = "resolvable_nodes";
+    public static final String TOTAL_ANSWER_TABLE_ENTRIES = "answer_table_entries";
 
     public final Counter timePlanning;
     public final Counter materialisations;
@@ -31,6 +33,8 @@ public class ReasonerPerfCounters extends PerfCounters {
     public final Counter compoundStreams;
     public final Counter compoundStreamMessagesReceived;
     public final Counter retrievableProcessors;
+    public final Counter resolvableNodes;
+    public final Counter answerTableEntries;
 
     public ReasonerPerfCounters(boolean enabled) {
         super(enabled);
@@ -40,6 +44,8 @@ public class ReasonerPerfCounters extends PerfCounters {
         compoundStreams = register(COMPOUND_STREAMS);
         compoundStreamMessagesReceived = register(COMPOUND_STREAM_MESSAGES_RECEIVED);
         retrievableProcessors = register(RETRIEVABLE_PROCESSORS);
+        resolvableNodes = register(RESOLVABLE_NODES);
+        answerTableEntries = register(TOTAL_ANSWER_TABLE_ENTRIES);
     }
 
     public void logCounters() {

--- a/reasoner/nodes/AnswerTable.java
+++ b/reasoner/nodes/AnswerTable.java
@@ -64,20 +64,6 @@ public class AnswerTable {
         return msg;
     }
 
-//    public Response.TreeVote recordTreePreVote(int target, int nodeId) {
-//        assert !complete;
-//        Response.TreeVote msg = new Response.TreeVote(answers.size(), target, null, nodeId);
-//        answers.add(msg);
-//        return msg;
-//    }
-//
-//    public Response.TreeVote recordTreePostVote(int target, int subtreeContribution, int nodeId) {
-//        assert !complete;
-//        Response.TreeVote msg = new Response.TreeVote(answers.size(), target, subtreeContribution, nodeId);
-//        answers.add(msg);
-//        return msg;
-//    }
-
     public Response.Done recordDone() {
         assert !complete;
         Response.Done msg = new Response.Done(answers.size());

--- a/reasoner/nodes/ConclusionNode.java
+++ b/reasoner/nodes/ConclusionNode.java
@@ -1,12 +1,16 @@
 package com.vaticle.typedb.core.reasoner.nodes;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.concept.Concept;
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.logic.Materialiser;
 import com.vaticle.typedb.core.logic.Rule;
 import com.vaticle.typedb.core.reasoner.planner.ConjunctionStreamPlan;
 import com.vaticle.typedb.core.reasoner.messages.Response;
+import com.vaticle.typedb.core.traversal.common.Identifier;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 public class ConclusionNode extends ActorNode<ConclusionNode> {
@@ -53,10 +57,10 @@ public class ConclusionNode extends ActorNode<ConclusionNode> {
         if (onPort.isReady()) onPort.readNext();
     }
 
-    // TODO: Undo public
-    public static synchronized Optional<Response.Conclusion> materialise(NodeRegistry nodeRegistry, Response.Answer msg, Rule.Conclusion conclusion) {
+    // TODO: Remove the synchronised.
+    public static Optional<Response.Conclusion> materialise(NodeRegistry nodeRegistry, Response.Answer msg, Rule.Conclusion conclusion) {
         Rule.Conclusion.Materialisable materialisable = conclusion.materialisable(msg.answer(), nodeRegistry.conceptManager());
-        Optional<Response.Conclusion> response = Materialiser
+        Optional<Response.Conclusion> response = nodeRegistry.materialiser()
                 .materialise(materialisable, nodeRegistry.traversalEngine(), nodeRegistry.conceptManager())
                 .map(materialisation -> materialisation.bindToConclusion(conclusion, msg.answer()))
                 .map(conclusionAnswer -> new Response.Conclusion(msg.index(), conclusionAnswer));

--- a/reasoner/nodes/ConclusionNode.java
+++ b/reasoner/nodes/ConclusionNode.java
@@ -61,7 +61,7 @@ public class ConclusionNode extends ActorNode<ConclusionNode> {
                 .map(materialisation -> materialisation.bindToConclusion(conclusion, msg.answer()))
                 .map(conclusionAnswer -> new Response.Conclusion(msg.index(), conclusionAnswer));
 
-        if (response.isPresent()) nodeRegistry.perfCounterFields().materialisations.add(1);
+        if (response.isPresent()) nodeRegistry.perfCounters().materialisations.add(1);
         return response;
     }
 }

--- a/reasoner/nodes/ConjunctionNode.java
+++ b/reasoner/nodes/ConjunctionNode.java
@@ -29,7 +29,7 @@ public class ConjunctionNode extends ActorNode<ConjunctionNode> {
         this.conjunction = conjunction;
         this.bounds = bounds;
         this.compoundStreamPlan = compoundStreamPlan;
-        nodeRegistry.perfCounterFields().subConjunctionNodes.add(1);
+        nodeRegistry.perfCounters().conjunctionProcessors.add(1);
     }
 
     @Override

--- a/reasoner/nodes/NodeRegistry.java
+++ b/reasoner/nodes/NodeRegistry.java
@@ -10,6 +10,7 @@ import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.concurrent.actor.Actor;
 import com.vaticle.typedb.core.concurrent.actor.ActorExecutorGroup;
 import com.vaticle.typedb.core.logic.LogicManager;
+import com.vaticle.typedb.core.logic.Materialiser;
 import com.vaticle.typedb.core.logic.Rule;
 import com.vaticle.typedb.core.logic.resolvable.*;
 import com.vaticle.typedb.core.pattern.variable.Variable;
@@ -57,6 +58,7 @@ public class NodeRegistry {
     // Terminated leaders violate monotonicity of the candidate. We must track & ignore their candidacy to prevent oscillation.
     // TODO: Consider an ArrayList?
     private final ConcurrentSet<Integer> terminatedNodes;
+    private final Materialiser materialiser;
 
     public NodeRegistry(ActorExecutorGroup executorService, ReasonerPerfCounters perfCounters,
                         ConceptManager conceptManager, LogicManager logicManager, TraversalEngine traversalEngine,
@@ -80,6 +82,7 @@ public class NodeRegistry {
         this.terminated = new AtomicBoolean(false);
         this.nodeAgeClock = new AtomicInteger();
         this.terminatedNodes = new ConcurrentSet<>();
+        materialiser = new Materialiser();
     }
 
     public void close() {} // TODO: Do we need to do anything?
@@ -284,6 +287,10 @@ public class NodeRegistry {
 
     public boolean isCandidateTerminated(Integer nodeId) {
         return terminatedNodes.contains(nodeId);
+    }
+
+    public Materialiser materialiser() {
+        return materialiser;
     }
 
     public abstract class SubRegistry<KEY, NODE extends ActorNode<NODE>> {

--- a/reasoner/nodes/NodeRegistry.java
+++ b/reasoner/nodes/NodeRegistry.java
@@ -37,7 +37,6 @@ import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 // TODO: See if we can use ConjunctionStreamPlan as the only one key we need. The nodes can do safe-downcasting
 public class NodeRegistry {
     private final ActorExecutorGroup executorService;
-    private final PerfCounterFields perfCountersFields;
     private final Map<ConjunctionStreamPlan.CompoundStreamPlan, SubConjunctionRegistry> conjunctionSubRegistries;
     private final Map<Rule.Conclusion, ConclusionRegistry> conclusionSubRegistries;
     private final Map<Retrievable, RetrievableRegistry> retrievableSubRegistries;
@@ -64,7 +63,6 @@ public class NodeRegistry {
                         ReasonerPlanner planner, Options.Transaction options) {
         this.executorService = executorService;
         this.perfCounters = perfCounters;
-        this.perfCountersFields = new PerfCounterFields(perfCounters);
         this.traversalEngine = traversalEngine;
         this.conceptManager = conceptManager;
         this.logicManager = logicManager;
@@ -280,11 +278,6 @@ public class NodeRegistry {
         return perfCounters;
     }
 
-    public PerfCounterFields perfCounterFields() {
-        return perfCountersFields;
-    }
-
-
     public void notifyNodeTermination(Integer nodeId) {
         terminatedNodes.add(nodeId);
     }
@@ -383,20 +376,4 @@ public class NodeRegistry {
 
     }
 
-    public class PerfCounterFields {
-        public final PerfCounters.Counter subConjunctionNodes;
-        public final PerfCounters.Counter resolvableNodes;
-        public final PerfCounters.Counter materialisations;
-        public final PerfCounters.Counter answersInTables;
-
-        private PerfCounterFields(PerfCounters perfCounters) {
-
-            subConjunctionNodes = perfCounters.register("v4_subConjunctionNodes");
-            ;
-            resolvableNodes = perfCounters.register("v4_resolvableNodes");
-            materialisations = perfCounters.register("v4_materialisations");
-            answersInTables = perfCounters.register("v4_tabledAnswers");
-        }
-
-    }
 }

--- a/reasoner/nodes/ResolvableNode.java
+++ b/reasoner/nodes/ResolvableNode.java
@@ -25,7 +25,7 @@ public abstract class ResolvableNode<RESOLVABLE extends Resolvable<?>, NODE exte
         super(nodeRegistry, driver, () -> String.format("ResolvableNode[%s, %s]", resolvable, bounds));
         this.resolvable = resolvable;
         this.bounds = bounds;
-        nodeRegistry.perfCounterFields().resolvableNodes.add(1);
+        nodeRegistry.perfCounters().resolvableNodes.add(1);
     }
 
     @Override

--- a/server/common/Constants.java
+++ b/server/common/Constants.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import static com.vaticle.typedb.core.server.common.Util.getTypedbDir;
 
 public class Constants {
-
     static final File ASCII_LOGO_FILE = getTypedbDir().resolve("server/resources/typedb-ascii.txt").toFile();
     public static final Path CONFIG_PATH = getTypedbDir().resolve("server/conf/config.yml");
     public static final String TYPEDB_DISTRIBUTION_NAME = "TypeDB Core";

--- a/test/behaviour/reasoner/verification/ForwardChainingMaterialiser.java
+++ b/test/behaviour/reasoner/verification/ForwardChainingMaterialiser.java
@@ -49,11 +49,13 @@ public class ForwardChainingMaterialiser {
     private final Map<com.vaticle.typedb.core.logic.Rule, Rule> rules;
     private final CoreTransaction tx;
     private final Materialisations materialisations;
+    private final Materialiser materialiser;
     private List<Set<Rule>> rulePartitions;
 
     private ForwardChainingMaterialiser(CoreSession session) {
         this.rules = new HashMap<>();
         this.tx = session.transaction(Arguments.Transaction.Type.WRITE, new Options.Transaction().infer(false));
+        this.materialiser = new Materialiser();
         this.materialisations = new Materialisations();
         this.rulePartitions = null;
     }
@@ -207,7 +209,7 @@ public class ForwardChainingMaterialiser {
         private Optional<Map<Identifier.Variable, Concept>> materialiseAndBind(
                 com.vaticle.typedb.core.logic.Rule.Conclusion conclusion, ConceptMap whenConcepts, TraversalEngine traversalEng, ConceptManager conceptMgr
         ) {
-            return Materialiser.materialise(conclusion.materialisable(whenConcepts, conceptMgr), traversalEng, conceptMgr)
+            return materialiser.materialise(conclusion.materialisable(whenConcepts, conceptMgr), traversalEng, conceptMgr)
                     .map(materialisation -> materialisation.bindToConclusion(conclusion, whenConcepts));
         }
 

--- a/test/benchmark/reasoner/iam/common/BenchmarkRunner.java
+++ b/test/benchmark/reasoner/iam/common/BenchmarkRunner.java
@@ -140,7 +140,7 @@ public class BenchmarkRunner {
                 Instant start = Instant.now();
                 long nAnswers = tx.query().get(TypeQL.parseQuery(query).asGet()).count();
                 Duration timeTaken = Duration.between(start, Instant.now());
-                run = new Benchmark.BenchmarkRun(nAnswers, timeTaken, ((CoreTransaction) tx).reasoner().controllerRegistry().perfCounters());
+                run = new Benchmark.BenchmarkRun(nAnswers, timeTaken, ((CoreTransaction) tx).reasoner().perfCounters());
             }
         }
         return run;

--- a/test/integration/logic/RuleTest.java
+++ b/test/integration/logic/RuleTest.java
@@ -31,6 +31,7 @@ import com.vaticle.typedb.core.test.integration.util.Util;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typeql.lang.TypeQL;
 import com.vaticle.typeql.lang.pattern.statement.ThingStatement;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -63,9 +64,15 @@ public class RuleTest {
     private static final Options.Database options = new Options.Database().dataDir(dataDir).reasonerDebuggerDir(logDir)
             .storageIndexCacheSize(MB).storageDataCacheSize(MB);
     private static String database = "rule-test";
+    private Materialiser materialiser;
 
     private Variable getVariable(Set<Variable> vars, Identifier identifier) {
         return iterate(vars).filter(v -> v.id().equals(identifier)).next();
+    }
+
+    @Before
+    public void createMaterialiser() {
+        materialiser = new Materialiser();
     }
 
     @BeforeClass
@@ -111,7 +118,7 @@ public class RuleTest {
                     ConceptMap whenAnswer = new ConceptMap(map(pair(Identifier.Variable.namedConcept("x"), people.get(0)),
                             pair(Identifier.Variable.namedConcept("y"), people.get(1))));
 
-                    Optional<Map<Identifier.Variable, Concept>> materialisation = rule.conclusion().materialiseAndBind(whenAnswer, txn.traversal(), conceptMgr);
+                    Optional<Map<Identifier.Variable, Concept>> materialisation = rule.conclusion().materialiseAndBind(materialiser, whenAnswer, txn.traversal(), conceptMgr);
                     assertTrue(materialisation.isPresent());
                     assertEquals(5, materialisation.get().size());
 
@@ -167,7 +174,7 @@ public class RuleTest {
                     ConceptMap whenAnswer = new ConceptMap(map(pair(Identifier.Variable.namedConcept("x"), people.get(0)),
                             pair(Identifier.Variable.namedConcept("y"), people.get(1))));
 
-                    Optional<Map<Identifier.Variable, Concept>> materialisation = rule.conclusion().materialiseAndBind(whenAnswer, txn.traversal(), conceptMgr);
+                    Optional<Map<Identifier.Variable, Concept>> materialisation = rule.conclusion().materialiseAndBind(materialiser, whenAnswer, txn.traversal(), conceptMgr);
                     assertFalse(materialisation.isPresent());
                 }
             }
@@ -209,7 +216,7 @@ public class RuleTest {
                     Rule rule = txn.logic().getRule("old-milk-is-not-good");
                     ConceptMap whenAnswer = new ConceptMap(map(pair(Identifier.Variable.namedConcept("x"), milkInst),
                             pair(Identifier.Variable.namedConcept("a"), ageInDays10)));
-                    Optional<Map<Identifier.Variable, Concept>> materialisation = rule.conclusion().materialiseAndBind(whenAnswer, txn.traversal(), conceptMgr);
+                    Optional<Map<Identifier.Variable, Concept>> materialisation = rule.conclusion().materialiseAndBind(materialiser, whenAnswer, txn.traversal(), conceptMgr);
                     assertTrue(materialisation.isPresent());
                     assertEquals(2, materialisation.get().size());
 
@@ -255,7 +262,7 @@ public class RuleTest {
 
                     Rule rule = txn.logic().getRule("old-milk-is-not-good");
                     ConceptMap whenAnswer = new ConceptMap(map(pair(Identifier.Variable.namedConcept("x"), milkInst)));
-                    Optional<Map<Identifier.Variable, Concept>> materialisation = rule.conclusion().materialiseAndBind(whenAnswer, txn.traversal(), conceptMgr);
+                    Optional<Map<Identifier.Variable, Concept>> materialisation = rule.conclusion().materialiseAndBind(materialiser, whenAnswer, txn.traversal(), conceptMgr);
                     assertTrue(materialisation.isPresent());
                     assertEquals(3, materialisation.get().size());
 


### PR DESCRIPTION
## What is the goal of this PR?
The move the `synchronized` construct from the materialise method of ConclusionNode deep into the materialiser. It is now present only on the relation materialisation branch and is synchronised on the type of the relation.

We also introduce a flag enabling "Relaxed relation inference semantics" - An relation will be inferred even if a persisted relation that subsumes it exists.  This is not enabled by default.